### PR TITLE
Command Securities and Permissions

### DIFF
--- a/src/utils/Permissions.js
+++ b/src/utils/Permissions.js
@@ -10,7 +10,7 @@ module.exports = class PermissionsTools {
 
         this.permissionsAllow = []
         this.permissionsAllowMissing = []
-
+        
         this.permissionsDeny = []
         this.permissionsDenyMissing = []
 

--- a/src/utils/PermissionsList.js
+++ b/src/utils/PermissionsList.js
@@ -1,72 +1,72 @@
 
 
 module.exports = {
-    CREATE_INSTANT_INVITE: {
+    createInvite: {
         name: "Create Instant Invite",
-        tag: "CREATE_INSTANT_INVITE",
+        tag: "createInvite",
         int: 0,
         to: 0,
         bits: 1 << 0,
         isGuild: true,
         isPrivate: false
     },
-    KICK_MEMBERS: {
+    kickMember: {
         name: "Kick Members",
-        tag: "KICK_MEMBERS",
+        tag: "kickMember",
         int: 0,
         to: 0,
         bits: 1 << 1,
         isGuild: true,
         isPrivate: false
     },
-    BAN_MEMBERS: {
+    banMember: {
         name: "Ban Members",
-        tag: "BAN_MEMBERS",
+        tag: "banMember",
         int: 0,
         to: 0,
         bits: 1 << 2,
         isGuild: true,
         isPrivate: false
     },
-    ADMINISTRATOR: {
+    administrator: {
         name: "Administrator",
-        tag: "ADMINISTRATOR",
+        tag: "administrator",
         int: 0,
         to: 0,
         bits: 1 << 3,
         isGuild: true,
         isPrivate: false
     },
-    MANAGE_CHANNEL: {
+    manageChannel: {
         name: "Manage Channels",
-        tag: "MANAGE_CHANNEL",
+        tag: "manageChannel",
         int: 0,
         to: 0,
         bits: 1 << 4,
         isGuild: true,
         isPrivate: false
     },
-    MESSAGE_ADD_REACTION: {
+    messageAddReaction: {
         name: "Add Reactions",
-        tag: "MESSAGE_ADD_REACTION",
+        tag: "messageAddReaction",
         int: 0,
         to: 0,
         bits: 1 << 6,
         isGuild: true,
         isPrivate: false
     },
-    VIEW_AUDIT_LOGS: {
+    auditLogs: {
         name: "View Audit Logs",
-        tag: "VIEW_AUDIT_LOGS",
+        tag: "auditLogs",
         int: 0,
         to: 0,
         bits: 1 << 7,
         isGuild: true,
         isPrivate: false
     },
-    VIEW_GUILD_INSIGHTS: {
+    guildInsights: {
         name: "View Server Insights",
-        tag: "VIEW_GUILD_INSIGHTS",
+        tag: "guildInsights",
         int: 0,
         to: 0,
         bits: 1 << 19,
@@ -74,9 +74,9 @@ module.exports = {
         isPrivate: false
     },
 
-    PRIORITY_SPEAKER: {
+    prioritySpeaker: {
         name: "Priority",
-        tag: "PRIORITY_SPEAKER",
+        tag: "prioritySpeaker",
         int: 0,
         to: 0,
         bits: 1 << 8,
@@ -84,9 +84,9 @@ module.exports = {
         isPrivate: false
     },
 
-    MANAGE_SERVER: {
+    manageGuild: {
         name: "GuildManager",
-        tag: "VIEW_GUILD_INSIGHTS",
+        tag: "manageGuild",
         int: 0,
         to: 0,
         bits: 1 << 5,
@@ -99,9 +99,9 @@ module.exports = {
     /**
      * This is applicable for all types of channels.
      */
-    VIEW_CHANNEL: {
+    viewChannel: {
         name: "Read channel text and view Voice Channels",
-        tag: "VIEW_CHANNEL",
+        tag: "viewChannel",
         int: 0,
         to: 0,
         bits: 1 << 10,
@@ -112,90 +112,90 @@ module.exports = {
     /**
      * Permissions of Text
      */
-    MESSAGE_READ: {
+    readMessageHistory: {
         name: "Read Messages",
-        tag: "MESSAGE_READ",
+        tag: "readMessageHistory",
         int: 0,
         to: 0,
         bits: 1 << 10,
         isGuild: true,
         isPrivate: false
     },
-    MESSAGE_WRITE: {
+    messageWrite: {
         name: "Send Messages",
-        tag: "MESSAGE_WRITE",
+        tag: "messageWrite",
         int: 0,
         to: 0,
         bits: 1 << 11,
         isGuild: true,
         isPrivate: false
     },
-    MESSAGE_TTS: {
+    messageTTS: {
         name: "Send TTS Messages",
-        tag: "MESSAGE_TTS",
+        tag: "messageTTS",
         int: 0,
         to: 0,
         bits: 1 << 12,
         isGuild: true,
         isPrivate: false
     },
-    MESSAGE_MANAGE: {
+    manageMessages: {
         name: "Manage Messages",
-        tag: "MESSAGE_MANAGE",
+        tag: "manageMessages",
         int: 0,
         to: 0,
         bits: 1 << 13,
         isGuild: true,
         isPrivate: false
     },
-    MESSAGE_EMBED_LINKS: {
+    embedLinks: {
         name: "Embed Links",
-        tag: "MESSAGE_EMBED_LINKS",
+        tag: "embedLinks",
         int: 0,
         to: 0,
         bits: 1 << 14,
         isGuild: true,
         isPrivate: false
     },
-    MESSAGE_ATTACH_FILES: {
+    attachFiles: {
         name: "Attach Files",
-        tag: "MESSAGE_ATTACH_FILES",
+        tag: "attachFiles",
         int: 0,
         to: 0,
         bits: 1 << 15,
         isGuild: true,
         isPrivate: false
     },
-    MESSAGE_HISTORY: {
+    messageHistory: {
         name: "Read History",
-        tag: "MESSAGE_HISTORY",
+        tag: "messageHistory",
         int: 0,
         to: 0,
         bits: 1 << 16,
         isGuild: true,
         isPrivate: false
     },
-    MESSAGE_MENTION_EVERYONE: {
+    mentionEveryone: {
         name: "Mention Everyone",
-        tag: "MESSAGE_MENTION_EVERYONE",
+        tag: "mentionEveryone",
         int: 0,
         to: 0,
         bits: 1 << 17,
         isGuild: true,
         isPrivate: false
     },
-    MESSAGE_EXT_EMOJI: {
+    externalEmojis: {
         name: "Use External Emojis",
-        tag: "MESSAGE_EXT_EMOJI",
+        tag: "externalEmojis",
         int: 0,
         to: 0,
         bits: 1 << 18,
         isGuild: true,
         isPrivate: false
     },
-    USE_SLASH_COMMANDS: {
+    useSlashCommands: {
         name: "Use Slash Commands",
-        tag: "USE_SLASH_COMMANDS",
+        tag: "useSlashCommands",
         int: 0,
         to: 0,
         bits: 1 << 31,
@@ -207,63 +207,63 @@ module.exports = {
     /**
      * Permissions Voice Channel
      */
-    VOICE_STREAM: {
+    voiceStream: {
         name: "Stream",
-        tag: "VOICE_STREAM",
+        tag: "voiceStream",
         int: 0,
         to: 0,
         bits: 1 << 9,
         isGuild: true,
         isPrivate: false
     },
-    VOICE_CONNECT: {
+    voiceConnect: {
         name: "Connect",
-        tag: "VOICE_CONNECT",
+        tag: "voiceConnect",
         int: 0,
         to: 0,
         bits: 1 << 20,
         isGuild: true,
         isPrivate: false
     },
-    VOICE_SPEAK: {
+    voiceSpeak: {
         name: "Speak",
-        tag: "VOICE_SPEAK",
+        tag: "voiceSpeak",
         int: 0,
         to: 0,
         bits: 1 << 21,
         isGuild: true,
         isPrivate: false
     },
-    VOICE_MUTE_OTHERS: {
+    voiceMuteOthers: {
         name: "Mute Members",
-        tag: "VOICE_MUTE_OTHERS",
+        tag: "voiceMuteOthers",
         int: 0,
         to: 0,
         bits: 1 << 22,
         isGuild: true,
         isPrivate: false
     },
-    VOICE_DEAF_OTHERS: {
+    voiceDeaf: {
         name: "Deafen Members",
-        tag: "VOICE_DEAF_OTHERS",
+        tag: "voiceDeafOthers",
         int: 0,
         to: 0,
         bits: 1 << 23,
         isGuild: true,
         isPrivate: false
     },
-    VOICE_MOVE_OTHERS: {
+    voiceMoveOthers: {
         name: "Move Members",
-        tag: "VOICE_MOVE_OTHERS",
+        tag: "voiceMoveOthers",
         int: 0,
         to: 0,
         bits: 1 << 24,
         isGuild: true,
         isPrivate: false
     },
-    VOICE_USE_VAD: {
+    voiceUseVad: {
         name: "Use Voice Activity",
-        tag: "VOICE_USE_VAD",
+        tag: "voiceUseVad",
         int: 0,
         to: 0,
         bits: 1 << 25,
@@ -274,54 +274,54 @@ module.exports = {
     /**
      * Guild
      */
-    NICKNAME_CHANGE: {
+    chanageNickname: {
         name: "Change Nickname",
-        tag: "NICKNAME_CHANGE",
+        tag: "chanageNickname",
         int: 0,
         to: 0,
         bits: 1 << 26,
         isGuild: true,
         isPrivate: false
     },
-    NICKNAME_MANAGE: {
+    manageNickname: {
         name: "Manage Nicknames",
-        tag: "NICKNAME_MANAGE",
+        tag: "manageNickname",
         int: 0,
         to: 0,
         bits: 1 << 27,
         isGuild: true,
         isPrivate: false
     },
-    MANAGE_ROLES: {
+    manageRoles: {
         name: "Manage Roles",
-        tag: "MANAGE_ROLES",
+        tag: "manageRoles",
         int: 0,
         to: 0,
         bits: 1 << 28,
         isGuild: true,
         isPrivate: false
     },
-    MANAGE_PERMISSIONS: {
+    managePermissions: {
         name: "Manage Permissions",
-        tag: "MANAGE_PERMISSIONS",
+        tag: "managePermissions",
         int: 0,
         to: 0,
         bits: 1 << 28,
         isGuild: true,
         isPrivate: false
     },
-    MANAGE_WEBHOOKS: {
+    manageWebhooks: {
         name: "Manage Webhooks",
-        tag: "MANAGE_WEBHOOKS",
+        tag: "manageWebhooks",
         int: 0,
         to: 0,
         bits: 1 << 29,
         isGuild: true,
         isPrivate: false
     },
-    MANAGE_EMOTES: {
+    manageEmotes: {
         name: "Manage Emojis",
-        tag: "MANAGE_EMOTES",
+        tag: "manageEmotes",
         int: 0,
         to: 0,
         bits: 1 << 30,

--- a/src/utils/commands/CommandRunner.js
+++ b/src/utils/commands/CommandRunner.js
@@ -2,6 +2,7 @@ const { dev } = require('../../../config')
 const i18next = require('i18next')
 const PermissionsTools = require('../Permissions')
 const CommandContext = require('./CommandContext')
+const PermissionsList = require('../PermissionsList')
 
 module.exports = class CommandRunner {
   constructor(client, msg) {
@@ -39,27 +40,39 @@ module.exports = class CommandRunner {
     if (command.config.developer && !dev.includes(this.msg.author.id)) return
     this.msg.channel.sendTyping()
     
-      for (let permission of command.config.permissions.user) {
-        let permissionCheck = new PermissionsTools(ctx.msg.member.permissions)
-        let positionPermision = permissionCheck.permissionsAllow.indexOf(permission.tag)
-        if (permissionCheck.permissionsAllow[positionPermision] === undefined) {
-          ctx.reply('ping_pong', `You don't have permission \`${permission.tag}\` to run this command!`)
-          return
-        }
+    for (let permission of command.config.permissions.user) {   
+      let permissionSelect = PermissionsList[permission]
+      if (typeof permissionSelect === 'object') {
+          let permissionCheck = new PermissionsTools(ctx.msg.member.permissions)
+          let positionPermision = permissionCheck.permissionsAllow.indexOf(permissionSelect.tag)
+          if (permissionCheck.permissionsAllow[positionPermision] === undefined) {
+            ctx.reply('ping_pong', `You don't have permission \`${permissionSelect.tag}\` to run this command!`)
+            return
+          }
+      } else {
+          ctx.reply('ping_pong', `Sorry there are unrecognized permissions and therefore the command cannot be executed for security reasons.`)
+          return 
       }
+    }
 
     if (command.config.permissions.bot.size >= 0) {
+
     } else {
       const getBot = this.msg.channel.guild.members.get(ctx.client.user.id)
-      for (let permission of command.config.permissions.bot) {
-        let permissionCheck = new PermissionsTools(getBot.permissions)
-        let positionPermision = permissionCheck.permissionsAllow.indexOf(permission.tag)
-        if (permissionCheck.permissionsAllow[positionPermision] === undefined) {
-          ctx.reply('ping_pong', `I do not have permission that \`${permission.tag}\` for this command!`)
-          return
+      for (let permission of command.config.permissions.bot) {   
+        let permissionSelect = PermissionsList[permission]
+        if (typeof permissionSelect === 'object') {
+          let permissionCheck = new PermissionsTools(getBot.permissions)
+          let positionPermision = permissionCheck.permissionsAllow.indexOf(permissionSelect.tag)
+          if (permissionCheck.permissionsAllow[positionPermision] === undefined) {
+            ctx.reply('ping_pong', `I do not have permission that \`${permissionSelect.tag}\` for this command!`)
+            return
+          }
+        } else {
+          ctx.reply('ping_pong', `Sorry there are unrecognized permissions and therefore the command cannot be executed for security reasons.`)
+          return 
         }
       }
-
     }
 
     command.run(ctx)


### PR DESCRIPTION
These implementations do not allow those commands that the server manages that do not ignore the wrong permission name or that do not exist so that something does not happen and the list is always verified and the command is automatically blocked on the spot.

When there is a wrong name in the permission list, the bot automatically says "Sorry there are unrecognized permissions and therefore the command cannot be executed for security reasons.". I made a change to the whitelist kind of readjusting as requested.