### PR TITLE
Added intents guildVoiceStates

### DIFF
--- a/config.js
+++ b/config.js
@@ -20,6 +20,7 @@ module.exports = {
       'guildBans',
       'guildEmojis',
       'guildMessages',
+      'guildVoiceStates',
       'guildMessageReactions',
       'directMessages',
       'directMessageReactions'


### PR DESCRIPTION
Without `guildVoiceStates` this ends up freezing the` VOICE_STATE_UPDATE` event without Lavacord taking metadata from the voice channel. So I am adding this so as not to hold the `VOICE_STATE_UPDATE`.